### PR TITLE
Add support for callbacks to the API

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,6 +36,18 @@ bundle('entry.js')
   .pipe(out); // output is a minified bundle with an inline source map
 ```
 
+You can also use callbacks to get your code and map in separate files
+
+```js
+bundle('entry.js')
+  .bundle({debug: true})
+  .pipe(minifyify(options, function (err, src, map) {
+    assert.ifError(err);
+    fs.writeFileSync('bundle.min.js', src);
+    fs.writeFileSync('bundle.min.map.json', map);
+  }))
+```
+
 ## Options
 
 ### [options.compressPath]

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,22 +1,47 @@
 var Minifier
   , through = require('through')
-  , optimize = require('./optimize');
+  , optimize = require('./optimize')
+  , concat = require('concat-stream');
 
-Minifier = function (opts) {
+Minifier = function (opts, cb) {
   var write
     , end
     , buff = '';
+
+  if(typeof opts == 'function') {
+    cb = opts;
+    opts = {
+      map: 'bundle.map.json'
+    };
+  }
 
   write = function (data) {
     buff += data;
   }
 
   end = function (data) {
-    var result = optimize(buff, opts);
+    try {
+      var result = optimize(buff, opts)
+        , decoupled;
+    }
+    catch(e) {
+      if(typeof cb == 'function')
+        return cb(e);
+    }
 
-    // Put the sourcemap inline
-    result.code = result.code.replace(/\s?;;;[^\t]\/\/@ sourceMappingURL[^\t]*$/, '') + '\n//@ sourceMappingURL=data:application/json;base64,'
-      + (new Buffer(result.map)).toString('base64');
+    // Strip out existing map
+    result.code = result.code.replace(/\s?;;;[^\t]\/\/(@|#) sourceMappingURL[^\t]*$/, '');
+
+    if(typeof cb == 'function') {
+      // Append the URL to the map
+      result.code += '\n//@ sourceMappingURL=' + opts.map;
+      cb(null, result.code, result.map);
+    }
+    else {
+      // Append the inline sourcemap
+      result.code += '\n//@ sourceMappingURL=data:application/json;base64,'
+        + (new Buffer(result.map)).toString('base64');
+    }
 
     this.queue(result.code);
     this.queue(null);


### PR DESCRIPTION
In response to #17, #13, we now have an easy way for you to get your code and sourcemap in separate files
