### PR TITLE
No source map option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,8 +36,10 @@ Minifier = function (opts, cb) {
     result.code = result.code.replace(/\s*\/\/(?:@|#) sourceMappingURL=(.*)$/m, '');
 
     if(typeof cb == 'function') {
-      // Append the URL to the map
-      result.code += '\n//# sourceMappingURL=' + opts.map;
+      // Append the URL to the map, unless map is set to false
+      if (opts.map) {
+        result.code += '\n//# sourceMappingURL=' + opts.map;  
+      }
       cb(null, result.code, result.map);
     }
     else {


### PR DESCRIPTION
While I personally enjoy source maps, it is certainly possible that someone could just want to minify and skip the source map piece, perhaps for something like a production build.

At the moment, this is not possible in minifyify, it either has to have the source map inline, or have a comment pointing to an external source map. This pull request makes it such that if you pass `false` as the value for the `map` option, there is no source map present.
