### PR TITLE
Fix bug when node.code isn't set

### DIFF
--- a/lib/registry/index.js
+++ b/lib/registry/index.js
@@ -108,7 +108,8 @@ Registry.prototype.minify = function (opts) {
 
   // Iterate through each node
   _.each(this.sourceNodes, function (node) {
-    minifyNode(node);
+    if (node.code)
+      minifyNode(node);
   });
 
   // Add the remaining code after the last node


### PR DESCRIPTION
I don't really know why this can happen, but when using minifyify on a project I got that node.code wasn't set (in the registry). This patched fixed it.
