### PR TITLE
join buffers with no comma in between

### DIFF
--- a/lib/minifier.js
+++ b/lib/minifier.js
@@ -113,7 +113,7 @@ Minifier.prototype.transformer = function (file) {
 
   end = function () {
     var thisStream = this
-      , unminCode = buffs.join()
+      , unminCode = buffs.join('')
       , originalCode = false
       , existingMap = convertSM.fromSource(unminCode)
       , finish;


### PR DESCRIPTION
Using minifyify from the command line will have no problems as I believe `write` in line 105 of `lib/minifier.js` will only be invoked once per file, somehow when I use it programatically, and in one case where the `brfs` module was in action, write was invoked more than once (I believe brfs emits `data` event once per transform that it applies) so the `buffs` array declared in line 100 had more than one position, and `['a','b'].join() === 'a,b'` but what you wanted is to actually join with no commas in between, so `['a','b'].join('') === 'ab'` which is the only way it will go through uglifyjs.
