### PR TITLE
add minify options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -66,6 +66,8 @@ Set to `false` to minify, but not produce a source map or append the source map 
 
 Set to false to disable minification and source map transforms. This essentially turns minifyify into a pass-thru stream.
 
+If you set it to an object, it will be passed as the options argument to `uglify.minify`.
+
 ### [options.output]
 
 Specify a path to write the sourcemap to. Required when using the CLI, optional when working programmatically.

--- a/lib/minifier.js
+++ b/lib/minifier.js
@@ -13,7 +13,8 @@ var Minifier
   , SM = require('source-map')
   , convertSM = require('convert-source-map')
   , SMConsumer = SM.SourceMapConsumer
-  , SMGenerator = SM.SourceMapGenerator;
+  , SMGenerator = SM.SourceMapGenerator
+  , extend = require('util')._extend;
 
 Minifier = function (opts) {
   /*
@@ -131,11 +132,17 @@ Minifier.prototype.transformer = function (file) {
 
     finish = function (tempExistingMapFile) {
       if(self.opts.minify) {
-        var min = uglify.minify(unminCode, {
-          fromString: true
-        , outSourceMap: (self.opts.map ? self.opts.map : undefined)
-        , inSourceMap: (self.opts.map ? tempExistingMapFile : undefined)
-        });
+        var opts = {
+            fromString: true
+          , outSourceMap: (self.opts.map ? self.opts.map : undefined)
+          , inSourceMap: (self.opts.map ? tempExistingMapFile : undefined)
+        };
+
+        if (typeof self.opts.minify === 'object') {
+          extend(opts, self.opts.minify);
+        }
+
+        var min = uglify.minify(unminCode, opts);
 
         thisStream.queue(min.code);
 


### PR DESCRIPTION
Hi, I thought it should be possible to pass more options to the `uglify.minify` options so I made this little change that should work.

I wanted to be able to do something like this:

``` js
module.exports = _grunt;
function _grunt (grunt) {
  grunt.initConfig({
    browserify: {
      dev: {
        files: {
          'build/js/main.min.js': 'js/app.js'
        },
        options: {
          transform: [
            'brfs',
          ],
          plugin: [
            ['minifyify', {
              map: 'main.min.map',
              output: 'build/js/main.min.map',
              drop_debugger: true, // passed to uglify.minify as well
              drop_console: true // and this too
            }]
          ]
        }
      }
    }
  });
}
```
