### PR TITLE
Use source-map 0.1.34 explicitly.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lodash.defaults": "2.4.x",
     "lodash.foreach": "2.4.x",
     "lodash.bind": "2.4.x",
-    "source-map": "0.1.x",
+    "source-map": "0.1.34",
     "uglify-js": "2.4.x",
     "convert-source-map": "^0.3.3",
     "tmp": "0.0.23"


### PR DESCRIPTION
Hello ben-ng,
I came across this error while using minifyify on some angular and angular-ui scripts:

`Fatal Error: "" is not in the set`

The error seems to originate from here:
https://github.com/mozilla/source-map/blob/master/lib/source-map/array-set.js#L71

After some searching around I found this:
https://github.com/mozilla/source-map/pull/121

Which is still unresolved. So maybe minifyify should stay at source-map 0.1.34 until this is resolved?
