### PR TITLE
Make sure bundleOpts is undefined, if no options.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,19 +23,19 @@ plugin = function (bundle, minifyifyOpts) {
     // Normalize options
     if(typeof bundleOpts == 'function') {
       bundleCb = bundleOpts;
-      bundleOpts = undefined;
-    }
-    else {
-      bundleOpts = bundleOpts || {};
     }
 
-    // Force debug mode for browserify < 5
-    bundleOpts.debug = true;
+    bundleOpts = bundleOpts || {};
 
     // For browserify 5, the bundle must be constructed with debug: true
     if(oldBundle.length === 1) {
       bundleOpts = undefined
+    } else {
+      // Force debug mode for browserify < 5
+      bundleOpts.debug = true;
     }
+
+
 
     /*
     * If no callback was given, require that the user


### PR DESCRIPTION
If no options were passed in to bundle, we shouldn't create a new
bundleOpts object. This is because in browserify 5, bundle options were
moved to the main browserify function. However, if bundle options are
passed in, we keep it around for backwards compatibility.

This fixed #56.
