### PR TITLE
Passthrough src if in debug mode but no srcmaps.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -86,8 +86,14 @@ plugin = function (bundle, minifyifyOpts) {
         }
       };
 
-      // Write the sourcemap to the specified output location
-      if(minifyifyOpts.minify && minifyifyOpts.output) {
+
+      if (!map && bundle._options.debug) {
+        // we don't have any sourcemap data but we browserify is in debug mode
+        // so, just pass src through
+        finish();
+      } else if(minifyifyOpts.minify && minifyifyOpts.output) {
+        // Write the sourcemap to the specified output location
+
         // This is so CLI users get a helpful error when their stuff breaks
         if(!map) {
           throw new Error('Run browserify in debug mode to use minifyify')

--- a/lib/minifier.js
+++ b/lib/minifier.js
@@ -197,7 +197,7 @@ Minifier.prototype.consumer = function (cb) {
       var bundle = self.decoupleBundle(data);
 
       if(bundle === false) {
-        return cb(new Error('Browserify must be in debug mode for minifyify to consume sourcemaps'));
+        return cb(null, convertSM.removeComments(data.toString()));
       }
 
       // Re-maps the browserify sourcemap


### PR DESCRIPTION
This checks browserify's options to check whether it was set up with `debug` or not. If it was but we still don't have sourcemaps, we just pass through the source data. Otherwise, things still happen as before.

This fixed #56.
