### PR TITLE
output is not needed when {map: false}

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,7 +41,7 @@ plugin = function (bundle, minifyifyOpts) {
     * If no callback was given, require that the user
     * specified a path to write the sourcemap out to
     */
-    if(!bundleStarted && !bundleCb && !minifyifyOpts.output) {
+    if(!bundleStarted && !bundleCb && !minifyifyOpts.output && minifyifyOpts.map) {
       throw new Error('Minifyify: opts.output is required since no callback was given');
     }
 


### PR DESCRIPTION
Output is only needed if there is no callback and a sourcemap should be generated
