### PR TITLE
Reset bundleStarted back to False after finishing.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,12 +81,16 @@ plugin = function (bundle, minifyifyOpts) {
       // A callback we'll need later
       finish = function () {
         // Otherwise, throw if anything bad happened
-        if(err) { throw err; }
+        if(err) {
+          bundleStarted = false;
+          throw err;
+        }
 
         // Push the minified src to our proxied stream
         minifiedStream.push(src);
         minifiedStream.push(null);
 
+        bundleStarted = false;
         if(typeof bundleCb == 'function') {
           return bundleCb(err, new Buffer(src), map);
         }

--- a/test/plugin-api.js
+++ b/test/plugin-api.js
@@ -185,4 +185,25 @@ tests['programmatic plugin api with minify=false and map'] = function (next) {
   });
 }
 
+// this is for Watchify
+tests['multiple bundles with the same transform'] = function (next) {
+  var bundler = new browserify({debug: true});
+  bundler.add(fixtures.entryScript('simple file'));
+  bundler.plugin(require('../lib'));
+  bundler.bundle(function (err, src, map) {
+    if(err) { throw err; }
+    assert.doesNotThrow(function () {
+      validate(src, map)
+    }, 'The bundle should have a valid sourcemap');
+
+    bundler.bundle(function (err, src, map) {
+      if(err) { throw err; }
+      assert.doesNotThrow(function () {
+        validate(src, map)
+      }, 'The bundle should have a valid sourcemap');
+      next();
+    });
+  });
+}
+
 module.exports = tests;


### PR DESCRIPTION
The plugin variable `bundleStarted` gets set on plugin initialization but never gets reset back. This means that only the first call to minifyify will ever succeed, while following calls will get aborted. This PR resets the variable when bundling finishes.

Related to issue #79, possibly also issue #70.