### PR TITLE
Add support for include/exclude filters using glob strings

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -112,6 +112,21 @@ Specify a path to write the sourcemap to. Required when using the CLI, optional 
 
 Will be passed to `uglify.minify`
 
+### [options.include]
+
+Pattern(s) matching the files you want included. Defaults to '**/*' (include everything).
+`null`/`undefined`, a single string, and an array of strings are all acceptable values.
+You have the full range of [glob](https://github.com/isaacs/node-glob#glob-primer)
+patterns available to you, so you can do `app/{moduleA,moduleB}/*.js`, etc.
+
+### [options.exclude]
+
+Pattern(s) matching the files you want excluded. By default _nothing_ is excluded.
+Like `include`; null, a string, and an array of strings are all acceptable.
+Exclude always wins over include.
+If a file matches both the `include` and `exclude` pattern arrays, it will be excluded.
+
+
 ## FAQ
 
  * PARSE ERROR!

--- a/Readme.md
+++ b/Readme.md
@@ -126,6 +126,11 @@ Like `include`; null, a string, and an array of strings are all acceptable.
 Exclude always wins over include.
 If a file matches both the `include` and `exclude` pattern arrays, it will be excluded.
 
+### [options.base]
+
+By default all glob strings are matched against relative paths from `process.cwd()` (your projects base directory).
+This option allows you to changed that. `base:'subDirA'` means evaluate globs relative from that sub directory.
+`base:'/'` means test your glob pattern against absolute file paths.
 
 ## FAQ
 

--- a/lib/minifier.js
+++ b/lib/minifier.js
@@ -58,7 +58,11 @@ Minifier = function (opts) {
   this.transformer = _.bind(this.transformer, this);
 
   // Apply glob string include/exclude filters
-  this.transformer = filter(opts.include, opts.exclude, this.transformer);
+  this.transformer = filter(this.transformer, {
+    include : opts.include,
+    exclude : opts.exclude,
+    base    : opts.base
+  });
 
   return this;
 };

--- a/lib/minifier.js
+++ b/lib/minifier.js
@@ -12,6 +12,7 @@ var Minifier
   , uglify = require('uglify-js')
   , SM = require('source-map')
   , convertSM = require('convert-source-map')
+  , filter = require('transform-filter')
   , SMConsumer = SM.SourceMapConsumer
   , SMGenerator = SM.SourceMapGenerator;
 
@@ -55,6 +56,9 @@ Minifier = function (opts) {
   * but we always want to refer to ourselves
   */
   this.transformer = _.bind(this.transformer, this);
+
+  // Apply glob string include/exclude filters
+  this.transformer = filter(opts.include, opts.exclude, this.transformer);
 
   return this;
 };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "source-map": "^0.3.0",
     "through": "^2.3.6",
     "tmp": "^0.0.24",
+    "transform-filter": "0.0.2",
     "uglify-js": "^2.4.16"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "source-map": "^0.3.0",
     "through": "^2.3.6",
     "tmp": "^0.0.24",
-    "transform-filter": "0.0.2",
+    "transform-filter": "^0.1.1",
     "uglify-js": "^2.4.16"
   },
   "scripts": {

--- a/test/bundles.js
+++ b/test/bundles.js
@@ -164,6 +164,25 @@ tests['complex file with filters'] = function (next) {
   );
 };
 
+tests['default base path'] = function (next) {
+  console.log(process.cwd())
+  testFilter(
+    'default base path',
+    {include:['**/*.js'], exclude:['test/fixtures/default base path/dirA/*.js', 'dirB/*.js']},
+    ['submodule.js',  'jsonthing.json'],  // doesn't exclude dirB
+    next
+  );
+};
+
+tests['custom base path'] = function (next) {
+  testFilter(
+    'custom base path',
+    {include:['**/*.js','*.js'], exclude:['dirA/*.js', 'dirB/*.js'], base:'test/fixtures/custom base path/'},
+    ['submodule.js','subsubmodule.js', 'jsonthing.json'],
+    next
+  );
+};
+
 tests['native libs'] = function (next) {
   testApp('native libs', next);
 };

--- a/test/bundles.js
+++ b/test/bundles.js
@@ -61,13 +61,12 @@ compileApp = function (appname, map, next) {
 /**
 * Builds, uploads, and validates an app
 */
-testApp = function(appname, cb) {
+testApp = function(appname, cb, opts) {
   var filename = fixtures.bundledFile(appname)
     , mapname = fixtures.bundledMap(appname)
     , destdir = fixtures.bundledDir(appname);
 
-  // Compile lib
-  compileApp(appname, function (min, map) {
+  function validateApp(min, map) {
     // Write to the build dir
     var appdir = path.join(fixtures.buildDir, 'apps', appname);
 
@@ -85,7 +84,10 @@ testApp = function(appname, cb) {
     }, appname + ' should not throw');
 
     cb();
-  });
+  }
+
+  // Compile lib
+  opts ? compileApp(appname, opts, validateApp) : compileApp(appname, validateApp);
 };
 
 tests['simple file'] = function (next) {
@@ -94,6 +96,18 @@ tests['simple file'] = function (next) {
 
 tests['complex file'] = function (next) {
   testApp('complex file', next);
+};
+
+tests['complex file with include filter'] = function (next) {
+  testApp('complex file with include filter', next, {include:'**/sub*.js'});
+};
+
+tests['complex file with exclude filter'] = function (next) {
+  testApp('complex file with exclude filter', next, {exclude:'**/sub*.js'});
+};
+
+tests['complex file with filters'] = function (next) {
+  testApp('complex file with filters', next, {include:['**/*.js'], exclude:['**/subsub*.js', '**/entry.js']});
 };
 
 tests['native libs'] = function (next) {

--- a/test/fixtures/complex file with exclude filter/entry.js
+++ b/test/fixtures/complex file with exclude filter/entry.js
@@ -1,0 +1,22 @@
+var submodule = require('./submodule')
+  , jsonthing = require('./jsonthing.json')
+  , myString
+  , actual
+  , expected;
+
+myString = submodule.createString(function () {
+  var mathy = 1 + 1 + 2 + 3 + 5 + 8;
+
+  mathy *= 1337;
+
+  return 'potato #' + mathy + jsonthing.turkey;
+});
+
+actual = document.createElement('pre');
+expected = document.createElement('pre');
+
+actual.innerHTML   = 'Actual:   ' + myString;
+expected.innerHTML = 'Expected: Wed Dec 31 1969 22:30:23 GMT-0800 (PST) friedpotato #26740salmonbakedpotato #26740salmonsliced potato #26740salmon';
+
+document.body.appendChild(actual);
+document.body.appendChild(expected)

--- a/test/fixtures/complex file with exclude filter/entry.js
+++ b/test/fixtures/complex file with exclude filter/entry.js
@@ -1,3 +1,5 @@
+// entry.js NOT_MINIFIED
+
 var submodule = require('./submodule')
   , jsonthing = require('./jsonthing.json')
   , myString
@@ -19,4 +21,4 @@ actual.innerHTML   = 'Actual:   ' + myString;
 expected.innerHTML = 'Expected: Wed Dec 31 1969 22:30:23 GMT-0800 (PST) friedpotato #26740salmonbakedpotato #26740salmonsliced potato #26740salmon';
 
 document.body.appendChild(actual);
-document.body.appendChild(expected)
+document.body.appendChild(expected);

--- a/test/fixtures/complex file with exclude filter/jsonthing.json
+++ b/test/fixtures/complex file with exclude filter/jsonthing.json
@@ -1,0 +1,3 @@
+{
+  "turkey": "salmon"
+}

--- a/test/fixtures/complex file with exclude filter/jsonthing.json
+++ b/test/fixtures/complex file with exclude filter/jsonthing.json
@@ -1,3 +1,4 @@
 {
+  "unminified":    "jsonthing.json",
   "turkey": "salmon"
 }

--- a/test/fixtures/complex file with exclude filter/submodule.js
+++ b/test/fixtures/complex file with exclude filter/submodule.js
@@ -1,0 +1,20 @@
+var subsubmodule = require('./subsubmodule');
+
+module.exports = {
+  createString: function (mathFunction) {
+    var date
+      , someNumber;
+
+    date = subsubmodule.getTheDate(function () {
+      var potatoes;
+
+      potatoes = ['fried', 'baked', 'sliced'];
+
+      return potatoes.join(mathFunction());
+    });
+
+    someNumber = mathFunction();
+
+    return date + ' ' + someNumber;
+  }
+};

--- a/test/fixtures/complex file with exclude filter/submodule.js
+++ b/test/fixtures/complex file with exclude filter/submodule.js
@@ -1,3 +1,5 @@
+// submodule.js NOT_MINIFIED
+
 var subsubmodule = require('./subsubmodule');
 
 module.exports = {

--- a/test/fixtures/complex file with exclude filter/subsubmodule.js
+++ b/test/fixtures/complex file with exclude filter/subsubmodule.js
@@ -1,0 +1,9 @@
+var getTheDate = function (someFunction) {
+  var someValue = someFunction();
+
+  return'Wed Dec 31 1969 22:30:23 GMT-0800 (PST) ' + someValue;
+};
+
+module.exports = {
+  getTheDate: getTheDate
+};

--- a/test/fixtures/complex file with exclude filter/subsubmodule.js
+++ b/test/fixtures/complex file with exclude filter/subsubmodule.js
@@ -1,3 +1,5 @@
+// subsubmodule.js NOT_MINIFIED
+
 var getTheDate = function (someFunction) {
   var someValue = someFunction();
 

--- a/test/fixtures/complex file with filters/entry.js
+++ b/test/fixtures/complex file with filters/entry.js
@@ -1,0 +1,22 @@
+var submodule = require('./submodule')
+  , jsonthing = require('./jsonthing.json')
+  , myString
+  , actual
+  , expected;
+
+myString = submodule.createString(function () {
+  var mathy = 1 + 1 + 2 + 3 + 5 + 8;
+
+  mathy *= 1337;
+
+  return 'potato #' + mathy + jsonthing.turkey;
+});
+
+actual = document.createElement('pre');
+expected = document.createElement('pre');
+
+actual.innerHTML   = 'Actual:   ' + myString;
+expected.innerHTML = 'Expected: Wed Dec 31 1969 22:30:23 GMT-0800 (PST) friedpotato #26740salmonbakedpotato #26740salmonsliced potato #26740salmon';
+
+document.body.appendChild(actual);
+document.body.appendChild(expected)

--- a/test/fixtures/complex file with filters/entry.js
+++ b/test/fixtures/complex file with filters/entry.js
@@ -1,3 +1,5 @@
+// entry.js NOT_MINIFIED
+
 var submodule = require('./submodule')
   , jsonthing = require('./jsonthing.json')
   , myString

--- a/test/fixtures/complex file with filters/jsonthing.json
+++ b/test/fixtures/complex file with filters/jsonthing.json
@@ -1,0 +1,3 @@
+{
+  "turkey": "salmon"
+}

--- a/test/fixtures/complex file with filters/jsonthing.json
+++ b/test/fixtures/complex file with filters/jsonthing.json
@@ -1,3 +1,4 @@
 {
+  "unminified":    "jsonthing.json",
   "turkey": "salmon"
 }

--- a/test/fixtures/complex file with filters/submodule.js
+++ b/test/fixtures/complex file with filters/submodule.js
@@ -1,0 +1,20 @@
+var subsubmodule = require('./subsubmodule');
+
+module.exports = {
+  createString: function (mathFunction) {
+    var date
+      , someNumber;
+
+    date = subsubmodule.getTheDate(function () {
+      var potatoes;
+
+      potatoes = ['fried', 'baked', 'sliced'];
+
+      return potatoes.join(mathFunction());
+    });
+
+    someNumber = mathFunction();
+
+    return date + ' ' + someNumber;
+  }
+};

--- a/test/fixtures/complex file with filters/submodule.js
+++ b/test/fixtures/complex file with filters/submodule.js
@@ -1,3 +1,5 @@
+// submodule.js NOT_MINIFIED
+
 var subsubmodule = require('./subsubmodule');
 
 module.exports = {

--- a/test/fixtures/complex file with filters/subsubmodule.js
+++ b/test/fixtures/complex file with filters/subsubmodule.js
@@ -1,0 +1,9 @@
+var getTheDate = function (someFunction) {
+  var someValue = someFunction();
+
+  return'Wed Dec 31 1969 22:30:23 GMT-0800 (PST) ' + someValue;
+};
+
+module.exports = {
+  getTheDate: getTheDate
+};

--- a/test/fixtures/complex file with filters/subsubmodule.js
+++ b/test/fixtures/complex file with filters/subsubmodule.js
@@ -1,3 +1,5 @@
+// subsubmodule.js NOT_MINIFIED
+
 var getTheDate = function (someFunction) {
   var someValue = someFunction();
 

--- a/test/fixtures/complex file with include filter/entry.js
+++ b/test/fixtures/complex file with include filter/entry.js
@@ -1,0 +1,22 @@
+var submodule = require('./submodule')
+  , jsonthing = require('./jsonthing.json')
+  , myString
+  , actual
+  , expected;
+
+myString = submodule.createString(function () {
+  var mathy = 1 + 1 + 2 + 3 + 5 + 8;
+
+  mathy *= 1337;
+
+  return 'potato #' + mathy + jsonthing.turkey;
+});
+
+actual = document.createElement('pre');
+expected = document.createElement('pre');
+
+actual.innerHTML   = 'Actual:   ' + myString;
+expected.innerHTML = 'Expected: Wed Dec 31 1969 22:30:23 GMT-0800 (PST) friedpotato #26740salmonbakedpotato #26740salmonsliced potato #26740salmon';
+
+document.body.appendChild(actual);
+document.body.appendChild(expected)

--- a/test/fixtures/complex file with include filter/entry.js
+++ b/test/fixtures/complex file with include filter/entry.js
@@ -1,3 +1,5 @@
+// entry.js NOT_MINIFIED
+
 var submodule = require('./submodule')
   , jsonthing = require('./jsonthing.json')
   , myString

--- a/test/fixtures/complex file with include filter/jsonthing.json
+++ b/test/fixtures/complex file with include filter/jsonthing.json
@@ -1,0 +1,3 @@
+{
+  "turkey": "salmon"
+}

--- a/test/fixtures/complex file with include filter/jsonthing.json
+++ b/test/fixtures/complex file with include filter/jsonthing.json
@@ -1,3 +1,4 @@
 {
+  "unminified":    "jsonthing.json",
   "turkey": "salmon"
 }

--- a/test/fixtures/complex file with include filter/submodule.js
+++ b/test/fixtures/complex file with include filter/submodule.js
@@ -1,0 +1,20 @@
+var subsubmodule = require('./subsubmodule');
+
+module.exports = {
+  createString: function (mathFunction) {
+    var date
+      , someNumber;
+
+    date = subsubmodule.getTheDate(function () {
+      var potatoes;
+
+      potatoes = ['fried', 'baked', 'sliced'];
+
+      return potatoes.join(mathFunction());
+    });
+
+    someNumber = mathFunction();
+
+    return date + ' ' + someNumber;
+  }
+};

--- a/test/fixtures/complex file with include filter/submodule.js
+++ b/test/fixtures/complex file with include filter/submodule.js
@@ -1,3 +1,5 @@
+// submodule.js NOT_MINIFIED
+
 var subsubmodule = require('./subsubmodule');
 
 module.exports = {

--- a/test/fixtures/complex file with include filter/subsubmodule.js
+++ b/test/fixtures/complex file with include filter/subsubmodule.js
@@ -1,0 +1,9 @@
+var getTheDate = function (someFunction) {
+  var someValue = someFunction();
+
+  return'Wed Dec 31 1969 22:30:23 GMT-0800 (PST) ' + someValue;
+};
+
+module.exports = {
+  getTheDate: getTheDate
+};

--- a/test/fixtures/complex file with include filter/subsubmodule.js
+++ b/test/fixtures/complex file with include filter/subsubmodule.js
@@ -1,3 +1,5 @@
+// subsubmodule.js NOT_MINIFIED
+
 var getTheDate = function (someFunction) {
   var someValue = someFunction();
 

--- a/test/fixtures/custom base path/dirA/submodule.js
+++ b/test/fixtures/custom base path/dirA/submodule.js
@@ -1,0 +1,22 @@
+// submodule.js NOT_MINIFIED
+
+var subsubmodule = require('../dirB/subsubmodule');
+
+module.exports = {
+  createString: function (mathFunction) {
+    var date
+      , someNumber;
+
+    date = subsubmodule.getTheDate(function () {
+      var potatoes;
+
+      potatoes = ['fried', 'baked', 'sliced'];
+
+      return potatoes.join(mathFunction());
+    });
+
+    someNumber = mathFunction();
+
+    return date + ' ' + someNumber;
+  }
+};

--- a/test/fixtures/custom base path/dirB/subsubmodule.js
+++ b/test/fixtures/custom base path/dirB/subsubmodule.js
@@ -1,0 +1,11 @@
+// subsubmodule.js NOT_MINIFIED
+
+var getTheDate = function (someFunction) {
+  var someValue = someFunction();
+
+  return'Wed Dec 31 1969 22:30:23 GMT-0800 (PST) ' + someValue;
+};
+
+module.exports = {
+  getTheDate: getTheDate
+};

--- a/test/fixtures/custom base path/entry.js
+++ b/test/fixtures/custom base path/entry.js
@@ -1,0 +1,24 @@
+// entry.js NOT_MINIFIED
+
+var submodule = require('./dirA/submodule')
+  , jsonthing = require('./jsonthing.json')
+  , myString
+  , actual
+  , expected;
+
+myString = submodule.createString(function () {
+  var mathy = 1 + 1 + 2 + 3 + 5 + 8;
+
+  mathy *= 1337;
+
+  return 'potato #' + mathy + jsonthing.turkey;
+});
+
+actual = document.createElement('pre');
+expected = document.createElement('pre');
+
+actual.innerHTML   = 'Actual:   ' + myString;
+expected.innerHTML = 'Expected: Wed Dec 31 1969 22:30:23 GMT-0800 (PST) friedpotato #26740salmonbakedpotato #26740salmonsliced potato #26740salmon';
+
+document.body.appendChild(actual);
+document.body.appendChild(expected)

--- a/test/fixtures/custom base path/jsonthing.json
+++ b/test/fixtures/custom base path/jsonthing.json
@@ -1,0 +1,4 @@
+{
+  "unminified":    "jsonthing.json",
+  "turkey": "salmon"
+}

--- a/test/fixtures/default base path/dirA/submodule.js
+++ b/test/fixtures/default base path/dirA/submodule.js
@@ -1,0 +1,22 @@
+// submodule.js NOT_MINIFIED
+
+var subsubmodule = require('../dirB/subsubmodule');
+
+module.exports = {
+  createString: function (mathFunction) {
+    var date
+      , someNumber;
+
+    date = subsubmodule.getTheDate(function () {
+      var potatoes;
+
+      potatoes = ['fried', 'baked', 'sliced'];
+
+      return potatoes.join(mathFunction());
+    });
+
+    someNumber = mathFunction();
+
+    return date + ' ' + someNumber;
+  }
+};

--- a/test/fixtures/default base path/dirB/subsubmodule.js
+++ b/test/fixtures/default base path/dirB/subsubmodule.js
@@ -1,0 +1,11 @@
+// subsubmodule.js NOT_MINIFIED
+
+var getTheDate = function (someFunction) {
+  var someValue = someFunction();
+
+  return'Wed Dec 31 1969 22:30:23 GMT-0800 (PST) ' + someValue;
+};
+
+module.exports = {
+  getTheDate: getTheDate
+};

--- a/test/fixtures/default base path/entry.js
+++ b/test/fixtures/default base path/entry.js
@@ -1,0 +1,24 @@
+// entry.js NOT_MINIFIED
+
+var submodule = require('./dirA/submodule')
+  , jsonthing = require('./jsonthing.json')
+  , myString
+  , actual
+  , expected;
+
+myString = submodule.createString(function () {
+  var mathy = 1 + 1 + 2 + 3 + 5 + 8;
+
+  mathy *= 1337;
+
+  return 'potato #' + mathy + jsonthing.turkey;
+});
+
+actual = document.createElement('pre');
+expected = document.createElement('pre');
+
+actual.innerHTML   = 'Actual:   ' + myString;
+expected.innerHTML = 'Expected: Wed Dec 31 1969 22:30:23 GMT-0800 (PST) friedpotato #26740salmonbakedpotato #26740salmonsliced potato #26740salmon';
+
+document.body.appendChild(actual);
+document.body.appendChild(expected)

--- a/test/fixtures/default base path/jsonthing.json
+++ b/test/fixtures/default base path/jsonthing.json
@@ -1,0 +1,4 @@
+{
+  "unminified":    "jsonthing.json",
+  "turkey": "salmon"
+}

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -16,7 +16,7 @@ var path = require('path')
       return path.join(BUILD_DIR, 'apps', name);
     }
   , bundledFile = function (name) {
-      return path.join(BUILD_DIR, name, 'bundle.min.js');
+      return path.join(BUILD_DIR, 'apps', name, 'bundle.min.js');
     }
   , bundledMap = function (name) {
       return path.join(BUILD_DIR, name, 'bundle.map.json');


### PR DESCRIPTION
usage:
```javascript
var opts = { 
  include : '**/*.js',  // single pattern
  exclude: [ 'test/**', 'node_modules/sinon/**' ] // multiple patterns in an array
};
```


* `include` defaults to matching everything (only specifically excluded files will not be minified),
* `exclude` defaults to matching nothing (nothing will be excluded).
* `exclude` takes precedence; If a file matches a pattern from both the `include` and `exclude` pattern arrays it will **not** be minified.