### PR TITLE
Handle backslashes in paths and verify sourceContent in test

### DIFF
--- a/lib/minifier.js
+++ b/lib/minifier.js
@@ -114,7 +114,7 @@ Minifier.prototype.transformer = function (file) {
     , throughStream;
 
   //Normalize the path separators to match what Browserify stores in the original Source Map
-  file = path.relative(basedir, file).replace(/\\/g, '/')
+  file = this.normalizePath(file);
 
   write = function (data) {
     if(self.opts.minify) {
@@ -305,8 +305,9 @@ Minifier.prototype.transformMap = function (bundleMap) {
 
   // Figure out where my minified files went in the bundle
   bundleMap.eachMapping(function (mapping) {
-    if(self.fileExists(mapping.source)) {
-      mapSourceToLine(mapping.source, mapping.generatedLine);
+    var source = self.normalizePath(mapping.source);
+    if(self.fileExists(source)) {
+      mapSourceToLine(source, mapping.generatedLine);
     }
     // Not a known source, pass thru the mapping
     else {
@@ -433,5 +434,16 @@ Minifier.prototype.decoupleBundle = function (src) {
   , map: new SMConsumer( map.toObject() )
   };
 };
+
+Minifier.prototype.normalizePath = function (file) {
+  // Is file a relative path?
+  if (!/^\w:|^\//.test(file)) {
+    return file.replace(/\\/g, '/');
+  }
+  // Resolve absolute paths relative to basedir
+  // Force '/' as path separator
+  var basedir = this.opts.basedir || process.cwd();
+  return path.relative(basedir, file).replace(/\\/g, '/');
+}
 
 module.exports = Minifier;

--- a/lib/minifier.js
+++ b/lib/minifier.js
@@ -114,7 +114,7 @@ Minifier.prototype.transformer = function (file) {
     , throughStream;
 
   //Normalize the path separators to match what Browserify stores in the original Source Map
-  file = path.relative(basedir, file)
+  file = path.relative(basedir, file).replace(/\\/g, '/')
 
   write = function (data) {
     if(self.opts.minify) {


### PR DESCRIPTION
Issue https://github.com/ben-ng/minifyify/issues/102

Minified paths always use `/` as separator. If scripts without a sourcemap use whatever path browserify provides.

Added sourcesContent verification in test/plugin-api.js. Requires exact match between sourcesContent and original source files.

All tests pass in OS X 10.10.3 for Browserify 5-10

All programmatic tests pass in Windows 8.1 for Browserify 5-10

The command line test (`['browserify -d -p minifyify --map mapFile > out.js'`) fails with error `The filename, directory name, or volume label syntax is incorrect` on Windows 8.1. I suspect making this test run on windows requires more intimate knowledge of the testing framework. At any rate, I can execute the produced command manually so there doesn't seem to be any problems with the package itself.