### PR TITLE
Clean up temp files.

### DIFF
--- a/lib/minifier.js
+++ b/lib/minifier.js
@@ -148,7 +148,7 @@ Minifier.prototype.transformer = function (file) {
       existingMap = false;
     }
 
-    finish = function (tempExistingMapFile) {
+    finish = function (tempExistingMapFile, cleanupCallback) {
       // Don't minify JSON!
       if(file.match(/\.json$/)) {
         try {
@@ -184,6 +184,11 @@ Minifier.prototype.transformer = function (file) {
           console.error('uglify-js failed on '+file+' : ' + e.toString());
           thisStream.queue(unminCode);
         }
+        finally {
+          if (typeof cleanupCallback === 'function') {
+            cleanupCallback();
+          }
+        }
       }
 
       // Otherwise we'll never finish
@@ -191,12 +196,18 @@ Minifier.prototype.transformer = function (file) {
     }
 
     if(existingMap) {
-      tmp.file(function (err, path) {
-        if(err) { throw err; }
+      tmp.file(function (err, path, fd, cleanupCallback) {
+        if(err) {
+          cleanupCallback();
+          throw err;
+        }
 
         fs.writeFile(path, existingMap, function (err) {
-          if(err) { throw err; }
-          finish(path);
+          if(err) {
+            cleanupCallback();
+            throw err;
+          }
+          finish(path, cleanupCallback);
         });
       });
     }


### PR DESCRIPTION
We use minifyify with gulp, and when running gulp watch, after some time the build stops working because the process has too many open files. This change makes minifyify clean up after itself.