### PR TITLE
fix: bundle() no longer accepts options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,7 +56,7 @@ plugin = function (bundle, minifyifyOpts) {
     }
 
     // Call browserify's bundle function and capture the output stream
-    bundleStream = oldBundle.call(bundle, bundleOpts);
+    bundleStream = oldBundle.call(bundle);
 
     /*
     * Browserify has this mechanism that delays bundling until all deps


### PR DESCRIPTION
I was getting the following error:

```
[Error: bundle() no longer accepts option arguments.
Move all option arguments to the browserify() constructor.]
minifyify/lib/index.js:78
    bundleStream.pipe(minifier.consumer(function (err, src, map) {
                ^
```