### PR TITLE
Change filename extension from .map.json to .js.map

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,7 +55,7 @@ var browserify = require('browserify')
 
 bundler.add('entry.js');
 
-bundler.plugin('minifyify', {map: 'bundle.map.json'});
+bundler.plugin('minifyify', {map: 'bundle.js.map'});
 
 bundler.bundle(function (err, src, map) {
   // Your code here
@@ -66,7 +66,7 @@ The map option should be the location of the sourcemap on your server, and is us
 
 ### Command Line
 ```sh
-$ browserify entry.js -d -p [minifyify --map bundle.map.json --output bundle.map.json] > bundle.js
+$ browserify entry.js -d -p [minifyify --map bundle.js.map --output bundle.js.map] > bundle.js
 ```
 
 The `--output` option is a required option on the command line interface and specifies where minifyify should write the sourcemap to on disk.
@@ -74,7 +74,7 @@ The `--output` option is a required option on the command line interface and spe
 Passing options to uglify-js is as easy as passing extra parameters in as an `uglify` object.
 
 ```sh
-$ browserify entry.js -d -p [minifyify --map bundle.map.json --output bundle.map.json --uglify [ --compress [ --dead_code--comparisons 0 ] ] ] > bundle.js
+$ browserify entry.js -d -p [minifyify --map bundle.js.map --output bundle.js.map --uglify [ --compress [ --dead_code--comparisons 0 ] ] ] > bundle.js
 ```
 
 In the example above, if you want to invoke minifyify to only minify


### PR DESCRIPTION
Fixes [issue 117](https://github.com/ben-ng/minifyify/issues/117). This makes the documentation to follow [source map naming conventions](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit#heading=h.txk3vdsh99hf).