### PR TITLE
Reset bundleStarted after bundleStream error.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -129,6 +129,7 @@ plugin = function (bundle, minifyifyOpts) {
 
     // Forward on the error event
     bundleStream.on('error', function (err) {
+      bundleStarted = false;
       minifiedStream.emit('error', err)
     })
 


### PR DESCRIPTION
Similar to #80, this change resets `bundleStarted` to `false` after a `bundleStream` error so that minifyify will work as expected on error-free bundle-ings that follow a bundling error. For example, with this change, minifyify will continue to work as expected with watchify even after a bundling error occurs, without requiring a reset of the watchify process.