### PR TITLE
forward writeStream errors to minifiedStream

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -116,6 +116,11 @@ plugin = function (bundle, minifyifyOpts) {
 
         var writeStream = fs.createWriteStream(minifyifyOpts.output);
 
+        // Forward on the error event
+        writeStream.on('error', function(err) {
+            minifiedStream.emit('error', err);
+        });
+
         // Delay completion until the map is written
         writeStream.on('close', finish);
 


### PR DESCRIPTION
In situations where the writeStream cannot write to the sourcemap file (such as when it doesn't have permissions), the entire process crashes. This will forward error events to the minifiedStream, so the user can handle them as needed.

I was going to write a test for this, but since git doesn't retain file permissions, I'm not sure of the best way to test this. @ben-ng if you have any feedback on how you think this could be tested, I'd be happy to write tests