### PR TITLE
Sort filenames before generating source map

### DIFF
--- a/lib/minifier.js
+++ b/lib/minifier.js
@@ -425,7 +425,7 @@ Minifier.prototype.transformMapping = function (file, mapping, offset) {
 Minifier.prototype.eachSource = function (cb) {
   var self = this;
 
-  _.each(this.registry, function(v, file) {
+  _.each(Object.keys(this.registry).sort(), function(file) {
     cb(file, self.codeForFile(file), self.mapForFile(file));
   });
 };


### PR DESCRIPTION
This maintains a consistent order avoiding unnecessary diffs.